### PR TITLE
Update changelog for version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+This page documents interesting or noteworthy changes to the project, based on [Semantic Versioning](http://semver.org/).
+
+### [1.0.0] - 2021-03-30
+
+- No new features, just fully backwards compatibility with @magnetis/astro 3.3.0 version


### PR DESCRIPTION
# What

First release for astro-css. It keeps the backwards compatibility with  astro last release. 