### PR TITLE
Remove old Magnetis developers from reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: npm
+- package-ecosystem: yarn
   directory: "/"
   schedule:
     interval: daily
@@ -14,40 +14,6 @@ updates:
   - murillo94
   - julianosbento
   - an-mag
-  - pleaobraga
-  - carlosberti
   - lopesalysson
   - pedro-cerdera
-  assignees:
-  - victorheringer
-  - murillo94
-  - julianosbento
-  - an-mag
-  - pleaobraga
-  - carlosberti
-  - lopesalysson
-  - pedro-cerdera
-  ignore:
-  - dependency-name: eslint
-    versions:
-    - 7.22.0
-    - 7.23.0
-    - 7.24.0
-  - dependency-name: cssnano
-    versions:
-    - 4.1.11
-  - dependency-name: stylelint
-    versions:
-    - 13.12.0
-  - dependency-name: svgo
-    versions:
-    - 2.2.2
-  - dependency-name: postcss-url
-    versions:
-    - 9.0.0
-  - dependency-name: stylelint-config-standard
-    versions:
-    - 20.0.0
-  - dependency-name: postcss-cli
-    versions:
-    - 7.1.2
+  - lucianomlima


### PR DESCRIPTION
- Remove old Magnetis developers from reviewers
- Change package ecosystem to yarn
- Remove assignee
- Remove ignored packages